### PR TITLE
Switch button type from enum to class

### DIFF
--- a/ui/lib/components/button/button.css
+++ b/ui/lib/components/button/button.css
@@ -21,7 +21,10 @@
 }
 
 .button--text {
-  border: 1px solid #ddd;
+  padding: 3px;
+}
+
+.button--icon {
   padding: 3px;
 }
 
@@ -58,147 +61,6 @@
   opacity: 0.6;
 }
 
-
-/* A simple x button to add a new tag */
-
-.button--remove {
-  width: 16px;
-  height: 16px;
-}
-
-.button--remove:before,
-.button--remove:after {
-  position: relative;
-  left: 7px;
-  top: 1px;
-  content: ' ';
-  height: 14px;
-  width: 2px;
-  background-color: #ccc;
-  display: block;
-}
-
-.button--remove:before {
-  transform: rotate(45deg);
-}
-
-.button--remove:after {
-  top: -13px;
-  transform: rotate(-45deg);
-}
-
-.tag:hover .button--remove {
-  opacity: 0.7;
-}
-
-.button--remove:hover:before,
-.button--remove:hover:after {
-  background-color: #888;
-}
-
-.button--remove:active:before,
-.button--remove:active:after {
-  background-color: #333;
-}
-
-/* A simple plus button to add a new tag */
-
-.button--add {
-  width: 16px;
-  height: 16px;
-}
-
-.button--add:before,
-.button--add:after {
-  position: relative;
-  left: 7px;
-  top: 1px;
-  content: ' ';
-  height: 14px;
-  width: 2px;
-  background-color: #ccc;
-  display: block;
-}
-
-.button--add:before {
-  transform: rotate(90deg);
-}
-
-.button--add:after {
-  top: -13px;
-}
-
-.message__tags:hover .button--add {
-  opacity: 0.7;
-}
-
-.button--add:hover:before,
-.button--add:hover:after {
-  background-color: #888;
-}
-
-.button--add:active:before,
-.button--add:active:after {
-  background-color: #333;
-}
-
-/* A simple tick button to add a new tag */
-
-.button--confirm {
-  width: 16px;
-  height: 16px;
-  margin: 2px;
-}
-
-.button--confirm:before,
-.button--confirm:after {
-  position: relative;
-  left: 7px;
-  top: 1px;
-  content: ' ';
-  height: 14px;
-  width: 2px;
-  background-color: #ccc;
-  display: block;
-}
-
-.button--confirm:before {
-  left: 10px;
-  height: 12px;
-  transform: rotate(40deg);
-}
-
-.button--confirm:after {
-  left: 4px;
-  top: -7px;
-  height: 7px;
-  transform: rotate(310deg);
-}
-
-.button--confirm:hover:before,
-.button--confirm:hover:after {
-  background-color: #888;
-}
-
-.button--confirm:active:before,
-.button--confirm:active:after {
-  background-color: #333;
-}
-
-
-/* A simple pencil button to edit something */
-
-.button--edit {
-  width: 16px;
-  height: 16px;
-  opacity: 0.6;
-  margin: 2px;
-}
-
-.button--edit:before {
-  content: '✎';
-  display: block;
-}
 
 .button--green:before,
 .button--green:after {

--- a/ui/lib/components/button/button.dart
+++ b/ui/lib/components/button/button.dart
@@ -2,18 +2,20 @@ import 'dart:html';
 
 typedef void OnEventCallback(Event e);
 
-enum ButtonType {
-  // Text buttons
-  text,
-  outlined,
-  contained,
+class ButtonType {
+  final String className;
+  final String iconClassName;
 
-  // Icon buttons
-  add,
-  remove,
-  confirm,
-  cancel,
-  edit,
+  const ButtonType(this.className, {this.iconClassName});
+
+  static const text = ButtonType("button--text");
+  static const outlined = ButtonType("button--outlined");
+  static const contained = ButtonType("button--contained");
+  static const add = ButtonType("button--icon", iconClassName: "fas fa-plus");
+  static const remove = ButtonType("button--icon", iconClassName: "far fa-trash-alt");
+  static const edit = ButtonType("button--icon", iconClassName: "fas fa-pen");
+  static const confirm = ButtonType("button--icon", iconClassName: "fas fa-check");
+  static const cancel = ButtonType("button--icon", iconClassName: "fas fa-times");
 }
 
 class ButtonAction {
@@ -29,51 +31,17 @@ class Button {
   Button(ButtonType buttonType, {String buttonText = '', String hoverText = '', OnEventCallback onClick}) {
     _element = new ButtonElement()
       ..classes.add('button')
-      ..title = hoverText;
+      ..classes.add(buttonType.className)
+      ..title = hoverText
+      ..text = buttonText;
+
+    if (buttonType.iconClassName != null) {
+      var icon = SpanElement()..className = buttonType.iconClassName;
+      _element.append(icon);
+    }
 
     onClick = onClick ?? (_) {};
     _element.onClick.listen(onClick);
-
-    switch (buttonType) {
-      case ButtonType.text:
-        _element.classes.add('button--text');
-        _element.text = buttonText;
-        break;
-      case ButtonType.outlined:
-        _element.classes.add('button--outlined');
-        _element.text = buttonText;
-        break;
-      case ButtonType.contained:
-        _element.classes.add('button--contained');
-        _element.text = buttonText;
-        break;
-
-      case ButtonType.add:
-        _element.classes.add('button-text');
-        var icon = SpanElement()..className = "fas fa-plus";
-        _element.append(icon);
-        break;
-      case ButtonType.remove:
-        _element.classes.add('button--text');
-        var icon = SpanElement()..className = "far fa-trash-alt";
-        _element.append(icon);
-        break;
-      case ButtonType.confirm:
-        _element.classes.add('button--text');
-        var icon = SpanElement()..className = "fas fa-check";
-        _element.append(icon);
-        break;
-      case ButtonType.edit:
-        _element.classes.add('button--text');
-        var icon = SpanElement()..className = "fas fa-pen";
-        _element.append(icon);
-        break;
-      case ButtonType.cancel:
-        _element.classes.add('button--text');
-        var icon = SpanElement()..className = "fas fa-times";
-        _element.append(icon);
-        break;
-    }
   }
 
   Element get renderElement => _element;


### PR DESCRIPTION
This is to support other icon buttons being created by users of the library for e.g. prototyping, as well as simplifying how buttons get created.

Also cleaning up pre-font awesome icon classes.


Note to self: this PR is on top of #51 , that one will need to be merged first, and the base branch changed to `main`