### PR TITLE
Fix bug: enter in freetext msg box moves to next conversation

### DIFF
--- a/ui/lib/components/messages/freetext_message_send.dart
+++ b/ui/lib/components/messages/freetext_message_send.dart
@@ -32,6 +32,9 @@ class FreetextMessageSendView {
     _textArea = TextAreaElement()
       ..defaultValue = _text
       ..placeholder = "Type your message..."
+      ..onKeyDown.listen((e) {
+        e.stopPropagation();
+      })
       ..onInput.listen((e) {
         _text = _textArea.value;
         _enableOrDisableButtons();
@@ -51,7 +54,7 @@ class FreetextMessageSendView {
       ..innerText = "${_text.length} / $_maxLength"
       ..className = "message-editor-with-send__text-length"
       ..hidden = !_alwaysShowTextLength;
-    
+
     var clearIcon = Element.html('<i class="fas fa-times"></i>');
     _clearButton = ButtonElement()
       ..append(clearIcon)


### PR DESCRIPTION
TBR @elayabharath 

Nook has a generic `document.onKeyDown.listen()` for handling shortcuts and so on `Enter` it moves the user to the next conversation and clears the textarea.