### PR TITLE
Change enter reaction to onKeyUp

### DIFF
--- a/ui/lib/components/messages/freetext_message_send.dart
+++ b/ui/lib/components/messages/freetext_message_send.dart
@@ -32,9 +32,6 @@ class FreetextMessageSendView {
     _textArea = TextAreaElement()
       ..defaultValue = _text
       ..placeholder = "Type your message..."
-      ..onKeyDown.listen((e) {
-        e.stopPropagation();
-      })
       ..onInput.listen((e) {
         _text = _textArea.value;
         _enableOrDisableButtons();

--- a/ui/lib/components/tag/tag.dart
+++ b/ui/lib/components/tag/tag.dart
@@ -153,6 +153,9 @@ class TagView {
     _tagText
       ..contentEditable = "true"
       ..onKeyDown.listen((event) {
+        if (event.keyCode == KeyCode.ENTER || event.keyCode == KeyCode.ESC) event.preventDefault();
+      })
+      ..onKeyUp.listen((event) {
         if (event.keyCode == KeyCode.ENTER) {
           event.preventDefault();
           _confirmEdit();


### PR DESCRIPTION
TBR - we don't need `stopPropagation` for `FreetextMessageSendView` b/c of https://github.com/larksystems/nook/pull/592/files, but we do need `preventDefault` for enter on tags, and then the handling of the enter and esc keys should be done on key up, otherwise by the time the key up event gets triggered, the tag is no longer an interactive element (!), and so Nook handles it like a shortcut