### PR TITLE
compare by most recent message if no inbound

### DIFF
--- a/ui/lib/components/model/model.dart
+++ b/ui/lib/components/model/model.dart
@@ -79,7 +79,7 @@ extension ConversationUtil on g.Conversation {
       return 0;
     }
     if (d1 == d2) {
-      return c1.docId.compareTo(c2.docId);
+      return mostRecentMessageFirst(c1, c2);
     }
     if (d1 == null) {
       return 1;


### PR DESCRIPTION
This behaviour makes a bit more sense from a user perspective, when we deal with lots of conversations with only outgoing messages, as well as lots of conversation with no messages at all at the same time.

TBR @elayabharath 