### PR TITLE
Protection against the search term exactly matching tag

### DIFF
--- a/ui/lib/components/autocomplete/autocomplete.dart
+++ b/ui/lib/components/autocomplete/autocomplete.dart
@@ -36,6 +36,8 @@ class AutocompleteList {
       _listFocusIndex = null;
     } else if (_listFocusIndex != null) {
       _listFocusIndex = 0;
+    } else if (input == activeSuggestions.first?._searchString) {
+      _listFocusIndex = 0;
     }
     _updateSuggestionListRender();
   }

--- a/ui/lib/components/tag/tag.dart
+++ b/ui/lib/components/tag/tag.dart
@@ -375,6 +375,10 @@ class NewTagViewWithSuggestions {
   }
 
   void _confirmEdit() {
-    onNewTag(_text);
+    if (_autocompleteList.activeSuggestions.first?.searchString == _text) {
+      onAcceptSuggestion(_autocompleteList.activeSuggestions.first.value);
+    } else {
+      onNewTag(_text);
+    }
   }
 }


### PR DESCRIPTION
If the tag name exactly matches the search term, choose the first matching term on pressing enter or choosing the confirm

Closes https://github.com/larksystems/Katikati-Core/issues/846