### PR TITLE
Add queryList param to project listener

### DIFF
--- a/ui/lib/datatypes/project.g.dart
+++ b/ui/lib/datatypes/project.g.dart
@@ -40,8 +40,8 @@ class Project {
   }
 
   static StreamSubscription listen(DocStorage docStorage, ProjectCollectionListener listener,
-          {String collectionRoot = '/$collectionName', OnErrorListener onError, @Deprecated('use onError instead') OnErrorListener onErrorListener}) =>
-      listenForUpdates<Project>(_log, docStorage, listener, collectionRoot, Project.fromSnapshot, onError: onError ?? onErrorListener);
+          {String collectionRoot = '/$collectionName', List<DocQuery> queryList, OnErrorListener onError, @Deprecated('use onError instead') OnErrorListener onErrorListener}) =>
+      listenForUpdates<Project>(_log, docStorage, listener, collectionRoot, Project.fromSnapshot, queryList: queryList, onError: onError ?? onErrorListener);
 
   Map<String, dynamic> toData() {
     return {


### PR DESCRIPTION
TBR cc @danrubel 

@danrubel when you next work on the codegen tool, would you be able to add this change to it? It completes the previously added [support for queries](https://github.com/larksystems/katikati_common_lib/pull/128/files). No rush - I don't anticipate to need it for another datatype urgently, and if I do, I can manually add it in etc.   Thanks in advance!

(Issue for tracking the propagation to other datatypes here https://github.com/larksystems/Katikati-Core/issues/903)